### PR TITLE
chore: add .gitlint to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,7 @@
 .editorconfig
 .gitattributes
 .gitignore
+.gitlint
 .prettierignore
 .vscode
 .vs


### PR DESCRIPTION
Minor change to avoid this warning:

```
$ prettier --check "**/**"
Checking formatting...
.gitlint[error] No parser could be inferred for file: .gitlint
All matched files use Prettier code style!
```