### PR TITLE
DE-135 - Gitlint fine tune

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,11 +1,10 @@
 [general]
 # Ignore certain rules (comma-separated list), you can reference them by
 # their id or by their full name
-ignore=body-is-missing,T3
+ignore=body-is-missing,body-max-line-length
 contrib=contrib-title-conventional-commits
 
 # Configure title-max-length rule, set title length to 20 (72 = default)
 [title-max-length]
 line-length=100
 # DEFAULT: line-length=72
-


### PR DESCRIPTION
* Restore rule `T3` (`title-trailing-punctuation`)
* Ignore rule `B1` (`body-max-line-length`)

See more information in https://jorisroovers.com/gitlint/rules/