### PR TITLE
Remove loggly-csharp-config dependency

### DIFF
--- a/Doppler.HelloMicroservice/Doppler.HelloMicroservice.csproj
+++ b/Doppler.HelloMicroservice/Doppler.HelloMicroservice.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.6" />
-    <PackageReference Include="loggly-csharp-config" Version="4.6.1.106" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />
     <PackageReference Include="Serilog.Exceptions" Version="6.1.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="4.1.2" />


### PR DESCRIPTION
It seems to not be longer required (See [doppler-mailer-system#520](https://github.com/MakingSense/doppler-mailer-system/pull/520)) and it is throwing an error:

```
Unhandled exception. System.IO.FileNotFoundException: Could not load file or assembly 'Loggly.Config, Version=4.6.1.76, Culture=neutral, PublicKeyToken=aea0e3c965ace843'. The system cannot find the file specified.
```