### PR TITLE
DE-227 - Consistent responses for unexpected errors

### DIFF
--- a/Doppler.HelloMicroservice.Test/Doppler.HelloMicroservice.Test.csproj
+++ b/Doppler.HelloMicroservice.Test/Doppler.HelloMicroservice.Test.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.8" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Doppler.HelloMicroservice.Test/IntegrationTest1.cs
+++ b/Doppler.HelloMicroservice.Test/IntegrationTest1.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Net;
+using System.Net.Http.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using Xunit;
 
 namespace Doppler.HelloMicroservice
@@ -23,8 +26,8 @@ namespace Doppler.HelloMicroservice
         [InlineData("/robots.txt", HttpStatusCode.OK, "text/plain")]
         [InlineData("/favicon.ico", HttpStatusCode.OK, "image/x-icon")]
         [InlineData("/swagger/v1/swagger.json", HttpStatusCode.OK, "application/json; charset=utf-8")]
-        [InlineData("/", HttpStatusCode.NotFound, null)]
-        [InlineData("/Not/Found", HttpStatusCode.NotFound, null)]
+        [InlineData("/", HttpStatusCode.NotFound, "application/problem+json; charset=utf-8")]
+        [InlineData("/Not/Found", HttpStatusCode.NotFound, "application/problem+json; charset=utf-8")]
         public async Task GET_endpoints_return_correct_status_and_contentType(string url, HttpStatusCode expectedStatusCode, string expectedContentType)
         {
             // Arrange
@@ -40,5 +43,43 @@ namespace Doppler.HelloMicroservice
             Assert.Equal(expectedStatusCode, response.StatusCode);
             Assert.Equal(expectedContentType, response.Content?.Headers?.ContentType?.ToString());
         }
+
+        [Fact]
+        public async Task GET_WeatherForecast_should_return_problem_details_when_there_is_an_unexpected_exception()
+        {
+            // Arrange
+            var exceptionMessage = "Test unexpected exception";
+            var weatherForecastServiceMock = new Mock<Weather.IWeatherForecastService>();
+            weatherForecastServiceMock.Setup(x => x.GetForecasts())
+                .Throws(new Exception(exceptionMessage));
+
+            var client = _factory
+                .WithWebHostBuilder(c =>
+                {
+                    c.ConfigureServices(s =>
+                    {
+                        s.AddSingleton(weatherForecastServiceMock.Object);
+                    });
+                })
+                .CreateClient(new WebApplicationFactoryClientOptions()
+                {
+                    AllowAutoRedirect = false
+                });
+
+            // Act
+            var response = await client.GetAsync("/WeatherForecast");
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.Equal("application/problem+json; charset=utf-8", response.Content?.Headers?.ContentType?.ToString());
+            Assert.Contains($"\"detail\":\"{exceptionMessage}\"", responseContent);
+            Assert.Contains("\"title\":\"Internal Server Error\"", responseContent);
+            Assert.Contains("\"type\":\"https://httpstatuses.com/500\"", responseContent);
+            Assert.Contains("\"status\":500", responseContent);
+            Assert.Contains("\"type\":\"System.Exception\"", responseContent);
+            Assert.Contains($"\"raw\":\"System.Exception: {exceptionMessage}", responseContent);
+        }
+
     }
 }

--- a/Doppler.HelloMicroservice/Controllers/WeatherForecastController.cs
+++ b/Doppler.HelloMicroservice/Controllers/WeatherForecastController.cs
@@ -13,9 +13,9 @@ namespace Doppler.HelloMicroservice.Controllers
     public class WeatherForecastController : ControllerBase
     {
         private readonly ILogger<WeatherForecastController> _logger;
-        private readonly WeatherForecastService _service;
+        private readonly IWeatherForecastService _service;
 
-        public WeatherForecastController(ILogger<WeatherForecastController> logger, WeatherForecastService service)
+        public WeatherForecastController(ILogger<WeatherForecastController> logger, IWeatherForecastService service)
         {
             _logger = logger;
             _service = service;

--- a/Doppler.HelloMicroservice/Doppler.HelloMicroservice.csproj
+++ b/Doppler.HelloMicroservice/Doppler.HelloMicroservice.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="5.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.8" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />
     <PackageReference Include="Serilog.Exceptions" Version="6.1.0" />

--- a/Doppler.HelloMicroservice/Startup.cs
+++ b/Doppler.HelloMicroservice/Startup.cs
@@ -27,7 +27,7 @@ namespace Doppler.HelloMicroservice
         {
             services.AddDopplerSecurity();
             services.AddControllers();
-            services.AddSingleton<Weather.WeatherForecastService>();
+            services.AddSingleton<Weather.IWeatherForecastService, Weather.WeatherForecastService>();
             services.AddSingleton<Weather.DataService>();
             services.AddSwaggerGen(c =>
             {

--- a/Doppler.HelloMicroservice/Startup.cs
+++ b/Doppler.HelloMicroservice/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
+using Hellang.Middleware.ProblemDetails;
 
 namespace Doppler.HelloMicroservice
 {
@@ -25,6 +26,7 @@ namespace Doppler.HelloMicroservice
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddProblemDetails();
             services.AddDopplerSecurity();
             services.AddControllers();
             services.AddSingleton<Weather.IWeatherForecastService, Weather.WeatherForecastService>();
@@ -64,10 +66,7 @@ namespace Doppler.HelloMicroservice
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            if (env.IsDevelopment())
-            {
-                app.UseDeveloperExceptionPage();
-            }
+            app.UseProblemDetails();
 
             app.UseSwagger();
             app.UseSwaggerUI(c => c.SwaggerEndpoint("v1/swagger.json", "Doppler.HelloMicroservice v1"));

--- a/Doppler.HelloMicroservice/Weather/IWeatherForecastService.cs
+++ b/Doppler.HelloMicroservice/Weather/IWeatherForecastService.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Doppler.HelloMicroservice.Weather
+{
+    public interface IWeatherForecastService
+    {
+        IEnumerable<WeatherForecast> GetForecasts();
+    }
+}

--- a/Doppler.HelloMicroservice/Weather/WeatherForecastService.cs
+++ b/Doppler.HelloMicroservice/Weather/WeatherForecastService.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace Doppler.HelloMicroservice.Weather
 {
-    public class WeatherForecastService
+    public class WeatherForecastService : IWeatherForecastService
     {
         private readonly DataService _dataService;
         public WeatherForecastService(DataService dataService)


### PR DESCRIPTION
Hi team, it is the same that I am applying in CD Helper:

> In our APIs, in general, we are using [Problem Details](https://datatracker.ietf.org/doc/html/rfc7807) for error responses, but it is not working in unexpected errors.
> 
> So, following the instructions in the [official documentation](https://docs.microsoft.com/en-us/aspnet/core/web-api/handle-errors?view=aspnetcore-6.0#producing-a-problemdetails-payload-for-exceptions), I have configured a middleware for this purpose.
> 
> <img width="1017" alt="image" src="https://user-images.githubusercontent.com/1157864/125818685-c1451163-802b-4b0a-9113-6d6bdf11b6c5.png">
> 
> <img width="893" alt="image" src="https://user-images.githubusercontent.com/1157864/125818692-abcdb698-f8d4-426d-9001-ae4db4db1200.png">
> 
> <img width="1091" alt="image" src="https://user-images.githubusercontent.com/1157864/125818705-26eb6feb-c70e-41e3-ab11-05c59c35a52f.png">

What do you think?